### PR TITLE
Update Contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,19 @@
 - `pnpm lint`
 - `pnpm lint:fix`
 
+## To run docs and tests at the same time
+
+```bash
+pnpm dev
+```
+
 ## Running the tests
 
-- `pnpm build` - an initial build is required to build the dist folder
+- `pnpm dev` - an initial build is required to build the dist folder. You need to run this command at least once.
 - `pnpm dev:ember` and then navigate to `/tests`
 
 ## Running the docs
 
-- `pnpm build` - an initial build is required to build the dist folder
+- `pnpm dev` - an initial build is required to build the dist folder. You need to run this command at least once.
 - `pnpm dev:docs`
 - navigate to `http://localhost:4200/docs`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,24 +2,22 @@
 
 ## Installation
 
-* `git clone <repository-url>`
-* `cd ember-aria`
-* `pnpm install`
+- `git clone <repository-url>`
+- `cd ember-aria`
+- `pnpm install`
 
 ## Linting
 
-* `pnpm lint`
-* `pnpm lint:fix`
+- `pnpm lint`
+- `pnpm lint:fix`
 
-## Running tests
+## Running the tests
 
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
+- `pnpm build` - an initial build is required to build the dist folder
+- `pnpm dev:ember` and then navigate to `/tests`
 
-## Running the test application
+## Running the docs
 
-* `ember serve`
-* Visit the test application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
+- `pnpm build` - an initial build is required to build the dist folder
+- `pnpm dev:docs`
+- navigate to `http://localhost:4200/docs`

--- a/testing/test-app/tests/rendering/aria-grid/node-selectors-test.ts
+++ b/testing/test-app/tests/rendering/aria-grid/node-selectors-test.ts
@@ -39,16 +39,14 @@ module('Rendering | node-selectors', function (hooks) {
   module('siblingsOf', function () {
     test('does not select nested cells in a nested grid', async function (assert) {
       await renderNestedGrid();
-      type Cell = {
-        id: string;
-      };
+
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       let firstCell = find('#cell-a')!;
       let siblings = siblingsOf(firstCell);
 
       assert.equal(siblings?.length, 2);
       assert.deepEqual(
-        siblings?.map((cell: Cell) => cell.id),
+        siblings?.map((cell) => cell.id),
         ['cell-a', 'cell-b']
       );
     });

--- a/testing/test-app/tests/rendering/aria-grid/node-selectors-test.ts
+++ b/testing/test-app/tests/rendering/aria-grid/node-selectors-test.ts
@@ -39,14 +39,16 @@ module('Rendering | node-selectors', function (hooks) {
   module('siblingsOf', function () {
     test('does not select nested cells in a nested grid', async function (assert) {
       await renderNestedGrid();
-
+      type Cell = {
+        id: string;
+      };
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       let firstCell = find('#cell-a')!;
       let siblings = siblingsOf(firstCell);
 
       assert.equal(siblings?.length, 2);
       assert.deepEqual(
-        siblings?.map((cell) => cell.id),
+        siblings?.map((cell: Cell) => cell.id),
         ['cell-a', 'cell-b']
       );
     });


### PR DESCRIPTION
 - ~fix a typescript error in the tests~
 - update the Contributing guide
   - this might be wildly incorrect
   - `pnpm dev` appears to be required before running `pnpm dev:ember` and `pnpm dev:docs` because the dist folder does not exist before this
   - `ember serve` was giving me errors like `You have to be inside an ember-cli proiect to use the test command.` even inside the `ember-aria-utilities` folder