### PR TITLE
fix: remove circular dependency

### DIFF
--- a/ember-aria-utilities/src/modifiers/-private/focus.ts
+++ b/ember-aria-utilities/src/modifiers/-private/focus.ts
@@ -2,7 +2,7 @@ import { assert } from '@ember/debug';
 
 import { isDevelopingApp, isTesting, macroCondition } from '@embroider/macros';
 
-import { enableNav } from './navigation';
+import { enableNav } from './navigation-state';
 import {
   cellRoles,
   cellSelector,

--- a/ember-aria-utilities/src/modifiers/-private/navigation-state.ts
+++ b/ember-aria-utilities/src/modifiers/-private/navigation-state.ts
@@ -1,0 +1,8 @@
+// presence means disabled
+const disabledGrids = new WeakSet<Element>();
+
+export const toggleNav = (grid: Element) =>
+  isNavDisabled(grid) ? enableNav(grid) : disableNav(grid);
+export const isNavDisabled = (grid: Element) => disabledGrids.has(grid);
+export const disableNav = (grid: Element) => disabledGrids.add(grid);
+export const enableNav = (grid: Element) => disabledGrids.delete(grid);

--- a/ember-aria-utilities/src/modifiers/-private/navigation.ts
+++ b/ember-aria-utilities/src/modifiers/-private/navigation.ts
@@ -14,18 +14,10 @@ import {
   upCell,
 } from './focus';
 import { DOWN, END, HOME, LEFT, PAGEDOWN, PAGEUP, RIGHT, UP } from './keys';
+import { isNavDisabled } from './navigation-state';
 import { isCell, nonHeaderCell } from './node-selectors';
 
 export const NAV_KEYS = [LEFT, DOWN, UP, RIGHT, HOME, END, PAGEDOWN, PAGEUP];
-
-// presence means disabled
-const disabledGrids = new WeakSet<Element>();
-
-export const toggleNav = (grid: Element) =>
-  isNavDisabled(grid) ? enableNav(grid) : disableNav(grid);
-export const isNavDisabled = (grid: Element) => disabledGrids.has(grid);
-export const disableNav = (grid: Element) => disabledGrids.add(grid);
-export const enableNav = (grid: Element) => disabledGrids.delete(grid);
 
 export function handleNavigation(
   event: KeyboardEvent,

--- a/ember-aria-utilities/src/modifiers/aria-grid.ts
+++ b/ember-aria-utilities/src/modifiers/aria-grid.ts
@@ -5,14 +5,8 @@ import { modifier } from 'ember-modifier';
 import { deFocus, focus, focusFirstFocusableWithin, focusSurroundGridOf } from './-private/focus';
 import { prepareFirstCell, setTabTarget } from './-private/focus-intent';
 import { ENTER, ESCAPE, F2 } from './-private/keys';
-import {
-  disableNav,
-  enableNav,
-  handleNavigation,
-  isNavDisabled,
-  NAV_KEYS,
-  toggleNav,
-} from './-private/navigation';
+import { handleNavigation, NAV_KEYS } from './-private/navigation';
+import { disableNav, enableNav, isNavDisabled, toggleNav } from './-private/navigation-state';
 import { cellSelector, isCell, isNestedGrid } from './-private/node-selectors';
 
 /**


### PR DESCRIPTION
## What changed
- moved some utility functions into another file, as this was causing a circular dependency

See: https://github.com/CrowdStrike/ember-aria/issues/17

```
(!) Circular dependency
[dev:*addon] [watch:*js] src/modifiers/-private/focus.ts -> src/modifiers/-private/navigation.ts -> src/modifiers/-private/focus.ts
```

This still doesn't fix the build problem I am having, but it makes my other PR in draft a bit easier to read once this change is merged.