### PR TITLE
fix: add watchman to ember-aria-utilities

### DIFF
--- a/ember-aria-utilities/.watchmanconfig
+++ b/ember-aria-utilities/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["tmp", "dist"]
+}


### PR DESCRIPTION
## What changed
- added a watchman config to ember-aria-utilities

## Why
`watch` mode is working for tests, but not for development for me. Something as little as adding a `console.log` to the `src` files was forcing me to stop and restart my server.

This appears to fix that?

## How to test 
1. run the master branch with `pnpm dev`
2. try adding a console.log here https://github.com/CrowdStrike/ember-aria/blob/main/ember-aria-utilities/src/modifiers/aria-grid.ts
3. note that the server still "builds" successfully to `localhost` but that you can't see the page if you go to the `docs`
4. checkout this branch, run `pnpm dev`
5. try adding a console.log here https://github.com/CrowdStrike/ember-aria/blob/main/ember-aria-utilities/src/modifiers/aria-grid.ts
6. Note that you can see the console.log