### PR TITLE
fix: remove timeout as the package is not in use

### DIFF
--- a/docs/tests/integration/sample-data-test.js
+++ b/docs/tests/integration/sample-data-test.js
@@ -3,8 +3,6 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { timeout } from 'ember-concurrency';
-
 module('Integration | Component | sample-data', function (hooks) {
   setupRenderingTest(hooks);
   test('it renders and displays data according to the timeout', async function (assert) {
@@ -37,7 +35,7 @@ module('Integration | Component | sample-data', function (hooks) {
     assert.dom('[data-test-selector=total-columns]').doesNotContainText();
     assert.dom('[data-test-selector=total-rows]').doesNotContainText();
 
-    await timeout(5000);
+    await new Promise(resolve => setTimeout(resolve, 5000));
 
     assert.dom('[data-test-selector=column]').hasAnyText();
     assert.dom('[data-test-selector=row]').hasAnyText();


### PR DESCRIPTION
## What changed
I removed this here: https://github.com/CrowdStrike/ember-aria/commit/6f2845c5200adf1bdecb98c768ca865bb727087b

It was requested here: https://github.com/CrowdStrike/ember-aria/pull/20#discussion_r998553261

It either:
a) didn't get merged
b) I lost it in a rebase somewhere

## How to test
Tests should pass.

