### PR TITLE
fix: revert gridSelectors to selectors

### DIFF
--- a/ember-aria-utilities/src/test-support/-private/aria-grid.ts
+++ b/ember-aria-utilities/src/test-support/-private/aria-grid.ts
@@ -7,7 +7,7 @@ import { DOWN, END, ENTER, ESCAPE, F2, HOME, LEFT, RIGHT, UP } from '../../modif
  *  NOTE: nth-child is 1-indexed
  *        we like math / graphs, so we convert to 0-indexed
  */
-const gridSelectors = {
+const selectors = {
   tabbable: '[tabindex="0"]',
   untabbable: '[tabindex="-1"]',
   cell: '[role="cell"]',
@@ -21,37 +21,37 @@ const gridSelectors = {
   bottomLeft: `[role="row"]:last-child [role="cell"]:first-child`,
 
   cellsInRow(n: number, append?: string) {
-    return `${gridSelectors.rowAt(n)} ${gridSelectors.cell}${append}`;
+    return `${selectors.rowAt(n)} ${selectors.cell}${append}`;
   },
 
   /**
    * To account for nested grids
    */
   rowsOf(grid: Element) {
-    let allRows = grid.querySelectorAll(gridSelectors.row);
+    let allRows = grid.querySelectorAll(selectors.row);
 
-    return [...allRows].filter((row) => row.closest(gridSelectors.grid) === grid);
+    return [...allRows].filter((row) => row.closest(selectors.grid) === grid);
   },
 
   rowAt(y?: number) {
     if (y === undefined) {
-      return `${gridSelectors.row}:first-child`;
+      return `${selectors.row}:first-child`;
     }
 
     // goal: (0, 0) is the first non-header cell
     // header is nth: 1 (we want it to be undefined)
     // first row is nth: 2 (we want it to be 0)
-    return `${gridSelectors.row}:nth-child(${y + 2})`;
+    return `${selectors.row}:nth-child(${y + 2})`;
   },
 
   cellAt(x: number, y?: number) {
-    let row = gridSelectors.rowAt(y);
+    let row = selectors.rowAt(y);
 
     if (y === undefined) {
-      return `${row} ${gridSelectors.header}:nth-child(${x + 1})`;
+      return `${row} ${selectors.header}:nth-child(${x + 1})`;
     }
 
-    return `${row} ${gridSelectors.cell}:nth-child(${x + 1})`;
+    return `${row} ${selectors.cell}:nth-child(${x + 1})`;
   },
 } as const;
 
@@ -111,7 +111,7 @@ function triggerable(key: string, options?: Parameters<typeof triggerKeyEvent>[3
    *
    */
   return (parent = '') => {
-    let target = document.querySelector(`${root} ${parent} ${gridSelectors.grid}`);
+    let target = document.querySelector(`${root} ${parent} ${selectors.grid}`);
 
     assert(`Target for ${key} not found`, target);
 
@@ -152,6 +152,6 @@ const keys = {
 
 export const ariaGrid = {
   keys,
-  gridSelectors,
+  selectors,
   tableSelectors,
 };

--- a/testing/test-app/tests/rendering/aria-grid-table-test.ts
+++ b/testing/test-app/tests/rendering/aria-grid-table-test.ts
@@ -17,7 +17,7 @@ import { ariaGrid } from 'ember-aria-utilities/test-support';
 
 import { repeat, withDefault } from '../helpers';
 
-const { keys, gridSelectors, tableSelectors } = ariaGrid;
+const { keys, selectors, tableSelectors } = ariaGrid;
 
 const debugAssert: typeof assert = assert;
 
@@ -219,7 +219,7 @@ module('{{aria-grid}}: <Table /> tests', function (hooks) {
 
         focus('#before');
 
-        let first = find(gridSelectors.cell);
+        let first = find(selectors.cell);
 
         assert.notEqual(document.activeElement, first);
 
@@ -236,7 +236,7 @@ module('{{aria-grid}}: <Table /> tests', function (hooks) {
           <button id='after'>after</button>
         `);
 
-        let others = findAll(gridSelectors.untabbable);
+        let others = findAll(selectors.untabbable);
         let last = others[others.length - 1];
 
         debugAssert(`Last untabbable not available`, last);

--- a/testing/test-app/tests/rendering/aria-grid-test.ts
+++ b/testing/test-app/tests/rendering/aria-grid-test.ts
@@ -18,7 +18,7 @@ import { ariaGrid } from 'ember-aria-utilities/test-support';
 
 import { Grid, NestedGrid, repeat, withDefault } from '../helpers';
 
-const { keys, gridSelectors } = ariaGrid;
+const { keys, selectors } = ariaGrid;
 
 const debugAssert: typeof assert = assert;
 
@@ -81,11 +81,11 @@ module('{{aria-grid}}', function (hooks) {
   function assertRowIndex(grid?: Element) {
     let index = 1; // rowindex is 1-indexed
 
-    let _grid = grid ?? find(gridSelectors.grid);
+    let _grid = grid ?? find(selectors.grid);
 
-    assert(`No "${gridSelectors.grid}" found in the DOM`, _grid);
+    assert(`No "${selectors.grid}" found in the DOM`, _grid);
 
-    let rows = gridSelectors.rowsOf(_grid);
+    let rows = selectors.rowsOf(_grid);
 
     for (let row of rows) {
       QUnit.assert.dom(row).hasAttribute('aria-rowindex', `${index}`);
@@ -126,14 +126,14 @@ module('{{aria-grid}}', function (hooks) {
   test('Only the first cell has tabindex=0', async function (assert) {
     await render(hbs`<Grid />`);
 
-    assert.dom(gridSelectors.tabbable).exists({ count: 1 });
+    assert.dom(selectors.tabbable).exists({ count: 1 });
   });
 
   test('Clicking a cell switches the tabindex=0 cell', async function (assert) {
     await render(hbs`<Grid />`);
 
-    let first = find(gridSelectors.tabbable);
-    let others = findAll(gridSelectors.untabbable);
+    let first = find(selectors.tabbable);
+    let others = findAll(selectors.untabbable);
 
     debugAssert(`No untabbable elements found`, Array.isArray(others));
 
@@ -143,7 +143,7 @@ module('{{aria-grid}}', function (hooks) {
 
     await click(lastElement);
 
-    let newTabTarget = find(gridSelectors.tabbable);
+    let newTabTarget = find(selectors.tabbable);
 
     assert.notEqual(first, newTabTarget);
   });
@@ -156,7 +156,7 @@ module('{{aria-grid}}', function (hooks) {
 
       await render(hbs`<Grid @rows={{2}} />`);
 
-      assert.dom(gridSelectors.grid).hasAttribute('aria-rowcount', '3', 'one header + 2 rows');
+      assert.dom(selectors.grid).hasAttribute('aria-rowcount', '3', 'one header + 2 rows');
 
       assertRowIndex(undefined);
     });
@@ -171,13 +171,13 @@ module('{{aria-grid}}', function (hooks) {
 
       await render(hbs`<Grid @rows={{this.rows}} />`);
 
-      assert.dom(gridSelectors.grid).hasAttribute('aria-rowcount', '5', 'one header + 4 rows');
+      assert.dom(selectors.grid).hasAttribute('aria-rowcount', '5', 'one header + 4 rows');
 
       this.setProperties({ rows: 10 });
 
       await settled();
 
-      assert.dom(gridSelectors.grid).hasAttribute('aria-rowcount', '11', 'one header + 10 rows');
+      assert.dom(selectors.grid).hasAttribute('aria-rowcount', '11', 'one header + 10 rows');
       assertRowIndex(undefined);
     });
 
@@ -205,7 +205,7 @@ module('{{aria-grid}}', function (hooks) {
         `
       );
 
-      let grids = findAll(gridSelectors.grid);
+      let grids = findAll(selectors.grid);
 
       assert.dom(grids[0]).hasAttribute('aria-rowcount', '3');
       assertRowIndex(grids[0]);
@@ -233,7 +233,7 @@ module('{{aria-grid}}', function (hooks) {
         `
       );
 
-      let grids = findAll(gridSelectors.grid);
+      let grids = findAll(selectors.grid);
 
       assert.dom(grids[0]).hasAttribute('aria-rowcount', '3');
       assert.dom('button').doesNotExist();
@@ -264,7 +264,7 @@ module('{{aria-grid}}', function (hooks) {
 
         focus('#before');
 
-        let first = find(gridSelectors.cell);
+        let first = find(selectors.cell);
 
         assert.notEqual(document.activeElement, first);
 
@@ -281,7 +281,7 @@ module('{{aria-grid}}', function (hooks) {
           <button id='after'>after</button>
         `);
 
-        let others = findAll(gridSelectors.untabbable);
+        let others = findAll(selectors.untabbable);
         let last = others[others.length - 1];
 
         debugAssert(`Last untabbable not available`, last);
@@ -300,7 +300,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Left', function () {
       test('when focus is on the left side', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.left();
@@ -309,7 +309,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is on the right side', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.cellsInRow(0, ':last-child'));
+        await click(selectors.cellsInRow(0, ':last-child'));
         assertActive(2, 0);
 
         await keys.left();
@@ -326,7 +326,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+Left', function () {
       test('when focus is on the left side', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.ctrlLeft();
@@ -335,7 +335,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is on the right side', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.cellsInRow(0, ':last-child'));
+        await click(selectors.cellsInRow(0, ':last-child'));
         assertActive(2, 0);
 
         await keys.ctrlLeft();
@@ -349,7 +349,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Right', function () {
       test('when focus is on the left side', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.right();
@@ -364,7 +364,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is on the right side', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.cellsInRow(0, ':last-child'));
+        await click(selectors.cellsInRow(0, ':last-child'));
         assertActive(2, 0);
 
         await keys.right();
@@ -375,7 +375,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+Right', function () {
       test('when focus is on the left side', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.ctrlRight();
@@ -387,7 +387,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is on the right side', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.cellsInRow(0, ':last-child'));
+        await click(selectors.cellsInRow(0, ':last-child'));
         assertActive(2, 0);
 
         await keys.ctrlRight();
@@ -398,7 +398,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Up', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.up();
@@ -410,7 +410,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the top', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.firstHeaderCell);
+        await click(selectors.firstHeaderCell);
         assertActive(0);
 
         await keys.up();
@@ -419,7 +419,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the bottom', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.bottomLeft);
+        await click(selectors.bottomLeft);
         assertActive(0, 2);
 
         await keys.up();
@@ -439,7 +439,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+Up', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.ctrlUp();
@@ -451,7 +451,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the top', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.firstHeaderCell);
+        await click(selectors.firstHeaderCell);
         assertActive(0);
 
         await keys.ctrlUp();
@@ -460,7 +460,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the bottom', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.bottomLeft);
+        await click(selectors.bottomLeft);
         assertActive(0, 2);
 
         await keys.ctrlUp();
@@ -477,7 +477,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Down', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.down();
@@ -489,7 +489,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the top', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.firstHeaderCell);
+        await click(selectors.firstHeaderCell);
         assertActive(0);
 
         await keys.down();
@@ -507,7 +507,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the bottom', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.bottomLeft);
+        await click(selectors.bottomLeft);
         assertActive(0, 2);
 
         await keys.down();
@@ -518,7 +518,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+Down', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.ctrlDown();
@@ -530,7 +530,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the top', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.firstHeaderCell);
+        await click(selectors.firstHeaderCell);
         assertActive(0);
 
         await keys.ctrlDown();
@@ -542,7 +542,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the bottom', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.bottomLeft);
+        await click(selectors.bottomLeft);
         assertActive(0, 2);
 
         await keys.ctrlDown();
@@ -553,7 +553,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Home', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.cellAt(0, 0));
+        await click(selectors.cellAt(0, 0));
         assertActive(0, 0);
 
         await keys.home();
@@ -565,7 +565,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus on some other cell', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.cellAt(1, 0));
+        await click(selectors.cellAt(1, 0));
         assertActive(1, 0);
 
         await keys.home();
@@ -577,7 +577,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus in the header', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.cellAt(1));
+        await click(selectors.cellAt(1));
         assertActive(1);
 
         await keys.home();
@@ -591,7 +591,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+Home', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid />`);
-        await click(gridSelectors.cellAt(0, 0));
+        await click(selectors.cellAt(0, 0));
         assertActive(0, 0);
 
         await keys.ctrlHome();
@@ -603,7 +603,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus on some other row', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.cellAt(0, 2));
+        await click(selectors.cellAt(0, 2));
         assertActive(0, 2);
 
         await keys.ctrlHome();
@@ -615,7 +615,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus in the header', async function () {
         await render(hbs`<Grid @rows={{3}} />`);
-        await click(gridSelectors.cellAt(0));
+        await click(selectors.cellAt(0));
         assertActive(0);
 
         await keys.ctrlHome();
@@ -629,7 +629,7 @@ module('{{aria-grid}}', function (hooks) {
     module('End', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid @columns={{3}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(0, 0));
+        await click(selectors.cellAt(0, 0));
         assertActive(0, 0);
 
         await keys.end();
@@ -641,7 +641,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus on some other cell', async function () {
         await render(hbs`<Grid @columns={{3}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(1, 1));
+        await click(selectors.cellAt(1, 1));
         assertActive(1, 1);
 
         await keys.end();
@@ -653,7 +653,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus in the header', async function () {
         await render(hbs`<Grid @columns={{3}} />`);
-        await click(gridSelectors.cellAt(1));
+        await click(selectors.cellAt(1));
         assertActive(1);
 
         await keys.end();
@@ -667,7 +667,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+End', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid @columns={{3}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(0, 0));
+        await click(selectors.cellAt(0, 0));
         assertActive(0, 0);
 
         await keys.ctrlEnd();
@@ -679,7 +679,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus on some other row', async function () {
         await render(hbs`<Grid @columns={{3}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(1, 1));
+        await click(selectors.cellAt(1, 1));
         assertActive(1, 1);
 
         await keys.ctrlEnd();
@@ -691,7 +691,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('with focus in the header', async function () {
         await render(hbs`<Grid @columns={{3}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(1));
+        await click(selectors.cellAt(1));
         assertActive(1);
 
         await keys.ctrlEnd();
@@ -715,7 +715,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+Home', function () {
       test('same behavior as without Ctrl', async function () {
         await render(hbs`<Grid @isMac={{true}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(0, 2));
+        await click(selectors.cellAt(0, 2));
         assertActive(0, 2);
 
         await keys.ctrlHome();
@@ -729,7 +729,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Ctrl+End', function () {
       test('same behavior as without Ctrl', async function () {
         await render(hbs`<Grid @isMac={{true}} @columns={{3}} @rows={{3}} />`);
-        await click(gridSelectors.cellAt(1, 1));
+        await click(selectors.cellAt(1, 1));
         assertActive(1, 1);
 
         await keys.ctrlEnd();
@@ -743,7 +743,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Apple+Left', function () {
       test('when focus is on the left side', async function () {
         await render(hbs`<Grid @isMac={{true}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.appleLeft();
@@ -752,7 +752,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is on the right side', async function () {
         await render(hbs`<Grid @isMac={{true}} @columns={{3}} />`);
-        await click(gridSelectors.cellsInRow(0, ':last-child'));
+        await click(selectors.cellsInRow(0, ':last-child'));
         assertActive(2, 0);
 
         await keys.appleLeft();
@@ -766,7 +766,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Apple+Right', function () {
       test('when focus is on the left side', async function () {
         await render(hbs`<Grid @isMac={{true}} @columns={{3}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.appleRight();
@@ -778,7 +778,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is on the right side', async function () {
         await render(hbs`<Grid @isMac={{true}} @columns={{3}} />`);
-        await click(gridSelectors.cellsInRow(0, ':last-child'));
+        await click(selectors.cellsInRow(0, ':last-child'));
         assertActive(2, 0);
 
         await keys.appleRight();
@@ -789,7 +789,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Apple+Up', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid @isMac={{true}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.appleUp();
@@ -801,7 +801,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the top', async function () {
         await render(hbs`<Grid @isMac={{true}} />`);
-        await click(gridSelectors.firstHeaderCell);
+        await click(selectors.firstHeaderCell);
         assertActive(0);
 
         await keys.appleUp();
@@ -810,7 +810,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the bottom', async function () {
         await render(hbs`<Grid @isMac={{true}} @rows={{3}} />`);
-        await click(gridSelectors.bottomLeft);
+        await click(selectors.bottomLeft);
         assertActive(0, 2);
 
         await keys.appleUp();
@@ -827,7 +827,7 @@ module('{{aria-grid}}', function (hooks) {
     module('Apple+Down', function () {
       test('with initial focus', async function () {
         await render(hbs`<Grid @isMac={{true}} @rows={{3}} />`);
-        await click(gridSelectors.tabbable);
+        await click(selectors.tabbable);
         assertActive(0, 0);
 
         await keys.appleDown();
@@ -839,7 +839,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the top', async function () {
         await render(hbs`<Grid @isMac={{true}} @rows={{3}} />`);
-        await click(gridSelectors.firstHeaderCell);
+        await click(selectors.firstHeaderCell);
         assertActive(0);
 
         await keys.appleDown();
@@ -851,7 +851,7 @@ module('{{aria-grid}}', function (hooks) {
 
       test('when focus is at the bottom', async function () {
         await render(hbs`<Grid @isMac={{true}} @rows={{3}} />`);
-        await click(gridSelectors.bottomLeft);
+        await click(selectors.bottomLeft);
         assertActive(0, 2);
 
         await keys.appleDown();
@@ -867,14 +867,14 @@ module('{{aria-grid}}', function (hooks) {
       await keys.right();
       await keys.down();
 
-      let rootGrid = find(gridSelectors.grid);
+      let rootGrid = find(selectors.grid);
       let expected = rootGrid?.querySelector(
-        `${gridSelectors.row}[id]:not([hidden]) > ${gridSelectors.cell}`
+        `${selectors.row}[id]:not([hidden]) > ${selectors.cell}`
       );
 
       assert.ok(expected);
       assert.strictEqual(document.activeElement, expected);
-      assert.strictEqual(document.activeElement?.closest(gridSelectors.grid), rootGrid);
+      assert.strictEqual(document.activeElement?.closest(selectors.grid), rootGrid);
     });
 
     skip('when focus in a nested grid, escape goes back to the last cell in the outer grid', async function () {
@@ -898,8 +898,8 @@ module('{{aria-grid}}', function (hooks) {
       await keys.down();
       await keys.down();
 
-      let rootGrid = find(gridSelectors.grid);
-      let rows = gridSelectors
+      let rootGrid = find(selectors.grid);
+      let rows = selectors
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         .rowsOf(rootGrid!)
         .filter((row: Element) => !row.hasAttribute('hidden'));
@@ -907,7 +907,7 @@ module('{{aria-grid}}', function (hooks) {
 
       assert.ok(expected);
       assert.strictEqual(closestRow(document.activeElement), expected);
-      assert.strictEqual(document.activeElement?.closest(gridSelectors.grid), rootGrid);
+      assert.strictEqual(document.activeElement?.closest(selectors.grid), rootGrid);
 
       let buttons = findAll('button');
 
@@ -919,7 +919,7 @@ module('{{aria-grid}}', function (hooks) {
       await keys.up();
 
       assert.strictEqual(closestRow(document.activeElement), rows[0]);
-      assert.strictEqual(document.activeElement?.closest(gridSelectors.grid), rootGrid);
+      assert.strictEqual(document.activeElement?.closest(selectors.grid), rootGrid);
     });
   });
 });


### PR DESCRIPTION
## What Changed
Changed `gridSelectors` back to `selectors`

## Why
Changing `gridSelectors` to `selectors` is actually a breaking change. Moving it back to `selectors` makes the overall last set of changes a minor (not major change).

I also wasn't sure how to update the release with a breaking change without changing any code...so I took this approach.